### PR TITLE
Ruby3 を追加

### DIFF
--- a/Dockerfile.API
+++ b/Dockerfile.API
@@ -2,20 +2,9 @@ FROM golang:1.21 as builder
 
 WORKDIR /go/src/github.com/yosupo06/library-checker-judge/api
 
-COPY ./api/go.mod /go/src/github.com/yosupo06/library-checker-judge/api/
-COPY ./api/go.sum /go/src/github.com/yosupo06/library-checker-judge/api/
-
-COPY ./database/go.mod /go/src/github.com/yosupo06/library-checker-judge/database/
-COPY ./database/go.sum /go/src/github.com/yosupo06/library-checker-judge/database/
-
-COPY ./langs/go.mod /go/src/github.com/yosupo06/library-checker-judge/langs/
-COPY ./langs/go.sum /go/src/github.com/yosupo06/library-checker-judge/langs/
-
-RUN go mod download
-
-COPY ./api/. /go/src/github.com/yosupo06/library-checker-judge/api/
-COPY ./database/. /go/src/github.com/yosupo06/library-checker-judge/database/
-COPY ./langs/. /go/src/github.com/yosupo06/library-checker-judge/langs/
+COPY ./api /go/src/github.com/yosupo06/library-checker-judge/api
+COPY ./database /go/src/github.com/yosupo06/library-checker-judge/database
+COPY ./langs /go/src/github.com/yosupo06/library-checker-judge/langs
 
 RUN CGO_ENABLED=0 GOOS=linux go build .
 

--- a/judge/judge_test.go
+++ b/judge/judge_test.go
@@ -162,6 +162,10 @@ func TestRubyAplusBAC(t *testing.T) {
 	testAplusBAC(t, "ruby", "ac.rb")
 }
 
+func TestRuby3AplusBAC(t *testing.T) {
+	testAplusBAC(t, "ruby3", "ac.rb")
+}
+
 func TestCppAplusBWA(t *testing.T) {
 	testAplusB(t, "cpp", "wa.cpp", SAMPLE_IN_PATH, SAMPLE_OUT_PATH, "WA")
 }

--- a/langs/Dockerfile.RUBY3
+++ b/langs/Dockerfile.RUBY3
@@ -1,0 +1,10 @@
+FROM rust:alpine as init-builder
+WORKDIR /library-checker-init
+COPY init /library-checker-init
+RUN cargo build --release --target=x86_64-unknown-linux-musl
+
+FROM ruby:3.4.1-alpine
+
+COPY --from=init-builder /library-checker-init/target/x86_64-unknown-linux-musl/release/library-checker-init /usr/bin
+
+LABEL library-checker-image=true

--- a/langs/build.sh
+++ b/langs/build.sh
@@ -16,3 +16,4 @@ docker build -t library-checker-images-golang -f $SCRIPT_DIR/Dockerfile.GOLANG $
 docker build -t library-checker-images-lisp -f $SCRIPT_DIR/Dockerfile.LISP $SCRIPT_DIR
 docker build -t library-checker-images-crystal -f $SCRIPT_DIR/Dockerfile.CRYSTAL $SCRIPT_DIR
 docker build -t library-checker-images-ruby -f $SCRIPT_DIR/Dockerfile.RUBY $SCRIPT_DIR
+docker build -t library-checker-images-ruby3 -f $SCRIPT_DIR/Dockerfile.RUBY3 $SCRIPT_DIR

--- a/langs/langs.toml
+++ b/langs/langs.toml
@@ -119,3 +119,11 @@
     image_name = "library-checker-images-ruby"
     compile = ["ruby", "-w", "-c", "main.rb"]
     exec = ["ruby", "main.rb"]
+[[langs]]
+    id = "ruby3"
+    name = "Ruby3"
+    version = "ruby 3.4.1"
+    source = "main.rb"
+    image_name = "library-checker-images-ruby3"
+    compile = ["ruby", "-w", "-c", "main.rb"]
+    exec = ["ruby", "main.rb"]


### PR DESCRIPTION
runtime を追加するサンプル
`docker compose build --no-cache` で API server のコンテナを build し直せば runtime を追加できる